### PR TITLE
[#37] Use servlet filter to cache the plugin resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,8 @@
             <version>${version.mockito}</version>
             <scope>test</scope>
         </dependency>
+
+
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/org/jirban/jira/servlet/CacheHeaderFilter.java
+++ b/src/main/java/org/jirban/jira/servlet/CacheHeaderFilter.java
@@ -1,0 +1,235 @@
+package org.jirban.jira.servlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Locale;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Kabir Khan
+ */
+public class CacheHeaderFilter implements Filter {
+
+    private final String etagHex = Long.toHexString(System.currentTimeMillis());
+    private static final int MAX_AGE = 60 * 5; //5 mins max age
+
+    public CacheHeaderFilter() {
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        CaptureStatusHttpServletResponse captureStatusHttpServletResponse = new CaptureStatusHttpServletResponse((HttpServletResponse) response);
+
+        HttpServletRequest req = (HttpServletRequest)request;
+        String ifNoneMatch = req.getHeader("if-none-match");
+
+        if (etagHex.equals(ifNoneMatch)) {
+            ((HttpServletResponse) response).setStatus(304);
+            return;
+        }
+
+        captureStatusHttpServletResponse.addHeader("ETag", etagHex);
+        captureStatusHttpServletResponse.addHeader("Cache-Control", "max-age=30"); //TODO set to 5 minutes or so
+        chain.doFilter(request, captureStatusHttpServletResponse);
+        int status = captureStatusHttpServletResponse.status;
+        if (status == 200) {
+            captureStatusHttpServletResponse.addHeader("ETag", etagHex);
+            captureStatusHttpServletResponse.addHeader("Cache-Control", "max-age=" + MAX_AGE); //TODO set to 5 minutes or so
+        }
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+    private static class CaptureStatusHttpServletResponse implements HttpServletResponse {
+        private final HttpServletResponse response;
+
+        private int status;
+
+        public CaptureStatusHttpServletResponse(HttpServletResponse response) {
+            this.response = response;
+        }
+
+        @Override
+        public void addCookie(Cookie cookie) {
+            response.addCookie(cookie);
+        }
+
+        @Override
+        public boolean containsHeader(String name) {
+            return response.containsHeader(name);
+        }
+
+        @Override
+        public String encodeURL(String url) {
+            return response.encodeURL(url);
+        }
+
+        @Override
+        public String encodeRedirectURL(String url) {
+            return response.encodeRedirectURL(url);
+        }
+
+        @Override
+        public String encodeUrl(String url) {
+            return response.encodeUrl(url);
+        }
+
+        @Override
+        public String encodeRedirectUrl(String url) {
+            return response.encodeRedirectUrl(url);
+        }
+
+        @Override
+        public void sendError(int sc, String msg) throws IOException {
+            this.status = sc;
+            response.sendError(sc, msg);
+        }
+
+        @Override
+        public void sendError(int sc) throws IOException {
+            this.status = sc;
+            response.sendError(sc);
+        }
+
+        @Override
+        public void sendRedirect(String location) throws IOException {
+            response.sendRedirect(location);
+        }
+
+        @Override
+        public void setDateHeader(String name, long date) {
+            response.setDateHeader(name, date);
+        }
+
+        @Override
+        public void addDateHeader(String name, long date) {
+            response.addDateHeader(name, date);
+        }
+
+        @Override
+        public void setHeader(String name, String value) {
+            response.setHeader(name, value);
+        }
+
+        @Override
+        public void addHeader(String name, String value) {
+            response.addHeader(name, value);
+        }
+
+        @Override
+        public void setIntHeader(String name, int value) {
+            response.setIntHeader(name, value);
+        }
+
+        @Override
+        public void addIntHeader(String name, int value) {
+            response.addIntHeader(name, value);
+        }
+
+        @Override
+        public void setStatus(int sc) {
+            this.status = sc;
+            response.setStatus(sc);
+        }
+
+        @Override
+        public void setStatus(int sc, String sm) {
+            this.status = sc;
+            response.setStatus(sc, sm);
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return response.getCharacterEncoding();
+        }
+
+        @Override
+        public String getContentType() {
+            return response.getContentType();
+        }
+
+        @Override
+        public ServletOutputStream getOutputStream() throws IOException {
+            return response.getOutputStream();
+        }
+
+        @Override
+        public PrintWriter getWriter() throws IOException {
+            return response.getWriter();
+        }
+
+        @Override
+        public void setCharacterEncoding(String charset) {
+            response.setCharacterEncoding(charset);
+        }
+
+        @Override
+        public void setContentLength(int len) {
+            response.setContentLength(len);
+        }
+
+        @Override
+        public void setContentType(String type) {
+            response.setContentType(type);
+        }
+
+        @Override
+        public void setBufferSize(int size) {
+            response.setBufferSize(size);
+        }
+
+        @Override
+        public int getBufferSize() {
+            return response.getBufferSize();
+        }
+
+        @Override
+        public void flushBuffer() throws IOException {
+            response.flushBuffer();
+        }
+
+        @Override
+        public void resetBuffer() {
+            response.resetBuffer();
+        }
+
+        @Override
+        public boolean isCommitted() {
+            return response.isCommitted();
+        }
+
+        @Override
+        public void reset() {
+            response.reset();
+        }
+
+        @Override
+        public void setLocale(Locale loc) {
+            response.setLocale(loc);
+        }
+
+        @Override
+        public Locale getLocale() {
+            return response.getLocale();
+        }
+    }
+}
+
+

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -11,17 +11,6 @@
   <!-- add our i18n resource -->
   <resource type="i18n" name="i18n" location="jirban-jira"/>
 
-  <!-- add our web resources -->
-  <!--
-  <web-resource key="jirban-jira-resources" name="jirban-jira Web Resources">
-    <dependency>com.atlassian.auiplugin:ajs</dependency>
-    <resource type="download" name="jirban-jira.css" location="/css/jirban-jira.css"/>
-    <resource type="download" name="jirban-jira.js" location="/js/jirban-jira.js"/>
-    <resource type="download" name="images/" location="/images"/>
-    <context>jirban-jira</context>
-  </web-resource>
-  -->
-
   <!-- Loads up the index.html page -->
   <servlet name="Jirban Index Servlet" i18n-name-key="index-servlet.name" key="index-servlet" class="org.jirban.jira.servlet.IndexServlet">
     <description>The welcome servlet which redirects to the angular2 client</description>
@@ -39,7 +28,17 @@
     <url-pattern>/rest/jirban/*</url-pattern>
   </servlet-filter>
 
-  <!-- Should be accessible under http://kabirmac.local:2990/jira/download/resources/org.jirban.jirban-jira/webapp/ -->
+  <!-- Add a filter to load up the valid user -->
+  <servlet-filter name="Jirban Cache Header Filter" i18n-name-key="auth-filter.name" key="cahe-header-filter" class="org.jirban.jira.servlet.CacheHeaderFilter" location="before-dispatch" weight="100">
+    <description>Filter adding cache headers to the resource requests.</description>
+    <!--
+      Need this since this is relative to the jira instance
+      https://developer.atlassian.com/jiradev/jira-platform/guides/other/tutorial-writing-jira-event-listeners-with-the-atlassian-event-library
+     -->
+    <url-pattern>/download/resources/org.jirban.jirban-jira/webapp</url-pattern>
+    <url-pattern>/download/resources/org.jirban.jirban-jira/webapp/*</url-pattern>
+  </servlet-filter>
+
   <resource type="download" name="webapp/" location="/webapp/"/>
 
   <!-- Active Objects configuration for configuration storage -->
@@ -51,7 +50,7 @@
 
   <web-item name="Jirban Agile Menu item" key="jirban-config" section="greenhopper_menu/greenhopper_menu_dropdown" weight="1000">
     <description>The Agile menu item taking you to the Jirban boards</description>
-    <label key="jirban.label"></label>
+    <label>Jirban Boards</label>
     <link linkId="jirban-config-link">/plugins/servlet/jirban</link>
     <condition class="org.jirban.jira.api.IsLoggedInCondition"/>
   </web-item>

--- a/src/main/resources/webapp/index.html
+++ b/src/main/resources/webapp/index.html
@@ -8,9 +8,9 @@
     <!-- 1. Load libraries -->
     <!-- Polyfill(s) for older browsers -->
     <script src="node_modules/core-js/client/shim.min.js"></script>
-    <script src="node_modules/zone.js/dist/zone.min.js"></script>
+    <script src="node_modules/zone.js/dist/zone.js"></script>
     <script src="node_modules/reflect-metadata/Reflect.js"></script>
-    <script src="node_modules/systemjs/dist/system.js"></script>
+    <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <!-- 2. Configure SystemJS -->
     <script src="systemjs.config.js"></script>
@@ -20,6 +20,6 @@
 
 </head>
 <body>
-<my-app>Loading Jirban...</my-app>
+<my-app>Loading...</my-app>
 </body>
 </html>


### PR DESCRIPTION
Fixes issue #37 

Use a servlet filter to set the cache headers, and validate the if-none-match (ETag) tokens
