### PR TITLE
[#70] Avoid duplicates in the access log, if the same board is access…

### DIFF
--- a/src/main/java/org/jirban/jira/impl/Constants.java
+++ b/src/main/java/org/jirban/jira/impl/Constants.java
@@ -40,6 +40,8 @@ public class Constants {
     public static final String COMPONENTS = "components";
     public static final String CONFIGS = "configs";
     public static final String CONFIG = "config";
+    public static final String CURRENT_BOARD = "current-board";
+    public static final String CURRENT_BOARD_LAST_LOGGED_ACCESS = "current-board-time";
     public static final String CUSTOM = "custom";
     public static final String DELETE = "delete";
     public static final String DONE = "done";


### PR DESCRIPTION
…ed within an hour (e.g. when toggling backlog)

Fixes #70
