### PR TITLE
[#67] Use history.replaceState to update link url

### DIFF
--- a/webapp/app/components/board/board.html
+++ b/webapp/app/components/board/board.html
@@ -18,7 +18,9 @@
 <!-- The panel with links to the control and health panels -->
 <panel-menu
         (toggleView)="onToggleView($event)"
-        [view]="view"></panel-menu>
+        [view]="view"
+        [linkUrl]="linkUrl"
+        (filtersUpdated)="onFiltersUpdated($event)"></panel-menu>
 <!-- The issue context menu -->
 <issue-context-menu *ngIf="issueContextMenuData" [issueContextMenuData]="issueContextMenuData" [view]="view" (closeContextMenu)="onCloseIssueContextMenu($event)"></issue-context-menu>
 <parallel-task-menu *ngIf="parallelTaskMenuData" [parallelTaskMenuData]="parallelTaskMenuData" (closeParallelTaskMenu)="onCloseParallelTaskMenu($event)"></parallel-task-menu>

--- a/webapp/app/components/board/controlPanel/controlPanel.ts
+++ b/webapp/app/components/board/controlPanel/controlPanel.ts
@@ -15,8 +15,8 @@ import {ParallelTask} from "../../../data/board/parallelTask";
 
 @Component({
     selector: 'control-panel',
-    inputs: ['view'],
-    outputs: ['closeControlPanel'],
+    inputs: ['view', 'linkUrl'],
+    outputs: ['closeControlPanel', 'filtersUpdated'],
     templateUrl: './controlPanel.html',
     styleUrls: ['./controlPanel.css']
 })
@@ -27,10 +27,9 @@ export class ControlPanelComponent {
     private _componentFilterForm:FormGroup;
 
     private closeControlPanel:EventEmitter<any> = new EventEmitter();
+    private filtersUpdated:EventEmitter<any> = new EventEmitter<any>();
 
     private none:string = NONE;
-
-    private linkUrl:string;
 
     private filtersToDisplay:string = null;
 
@@ -38,6 +37,8 @@ export class ControlPanelComponent {
     private filterTooltips:IMap<string> = {};
 
     private view:string;
+
+    private linkUrl:string;
 
     constructor(private boardData:BoardData) {
     }
@@ -168,15 +169,7 @@ export class ControlPanelComponent {
         this._assigneeFilterForm = assigneeFilterForm;
         this._componentFilterForm = componentFilterForm;
         this._controlForm = form;
-        this.updateLinkUrl();
         this.updateTooltips();
-
-        this.boardData.headers.stateVisibilitiesChangedObservable.subscribe((value:void) => {
-            this.updateLinkUrl();
-        });
-        this.boardData.swimlaneVisibilityObservable.subscribe((value:void) => {
-            this.updateLinkUrl();
-        });
 
         return this._controlForm;
     }
@@ -512,17 +505,7 @@ export class ControlPanelComponent {
 
 
     private updateLinkUrl() {
-        let url:string = window.location.href;
-        let index = url.lastIndexOf("?");
-        if (index >= 0) {
-            url = url.substr(0, index);
-        }
-        url = this.boardData.createQueryStringParticeles(url);
-        if (this.view != VIEW_KANBAN) {
-            url += "&view=" + this.view;
-        }
-
-        this.linkUrl = url;
+        this.filtersUpdated.emit({});
     }
 
 

--- a/webapp/app/components/board/panelMenu/panelMenu.html
+++ b/webapp/app/components/board/panelMenu/panelMenu.html
@@ -28,4 +28,8 @@
     </div>
 </div>
 <health-panel *ngIf="healthPanel" (closeHealthPanel)="onCloseHealthPanel($event)"></health-panel>
-<control-panel *ngIf="controlPanel" (closeControlPanel)="onCloseControlPanel($event)" [view]="view"></control-panel>
+<control-panel *ngIf="controlPanel"
+               (closeControlPanel)="onCloseControlPanel($event)"
+               (filtersUpdated)="onFiltersUpdated($event)"
+               [view]="view"
+               [linkUrl]="linkUrl"></control-panel>

--- a/webapp/app/components/board/panelMenu/panelMenu.ts
+++ b/webapp/app/components/board/panelMenu/panelMenu.ts
@@ -4,8 +4,8 @@ import {Hideable} from "../../../common/hide";
 
 @Component({
     selector: 'panel-menu',
-    inputs: ['view'],
-    outputs: ['toggleView'],
+    inputs: ['view', 'linkUrl'],
+    outputs: ['toggleView', 'filtersUpdated'],
     templateUrl: './panelMenu.html',
     styleUrls: ['./panelMenu.css']
 })
@@ -13,7 +13,9 @@ export class PanelMenuComponent implements Hideable {
     private controlPanel:boolean = false;
     private healthPanel:boolean = false;
     private toggleView:EventEmitter<any> = new EventEmitter<any>();
+    private filtersUpdated:EventEmitter<any> = new EventEmitter<any>();
     private view:boolean;
+    private linkUrl:string;
 
     constructor(private boardData:BoardData) {
         this.boardData.registerHideable(this);
@@ -46,5 +48,9 @@ export class PanelMenuComponent implements Hideable {
 
     onCloseControlPanel(event:Event) : void {
         this.controlPanel = false;
+    }
+
+    onFiltersUpdated(event:any) {
+        this.filtersUpdated.emit(event);
     }
 }


### PR DESCRIPTION
Drive the link url from the board rather than the control panel. FIxes #67
