### PR TITLE
IssueRegistry - removal of unused local variables

### DIFF
--- a/src/test/java/ut/org/jirban/jira/mock/IssueRegistry.java
+++ b/src/test/java/ut/org/jirban/jira/mock/IssueRegistry.java
@@ -105,7 +105,6 @@ public class IssueRegistry implements NextRankedIssueUtil {
 
     List<Issue> getIssueList(String searchIssueKey, String project, String searchStatus, Collection<String> doneStatesFilter) {
         if (searchIssueKey != null) {
-            String projectCode = searchIssueKey.substring(0, searchIssueKey.indexOf("-"));
             return Collections.singletonList(getIssue(searchIssueKey));
         }
         Map<String, MockIssue> issues = issuesByProject.get(project);
@@ -134,7 +133,6 @@ public class IssueRegistry implements NextRankedIssueUtil {
     public void rerankIssue(String issueKey, String beforeIssueKey) {
         String projectCode = getProjectCode(issueKey);
         Map<String, MockIssue> issues = issuesByProject.get(projectCode);
-        MockIssue issue = issues.get(issueKey);
         List<String> issueList = new ArrayList<>(issues.keySet());
         issueList.remove(issueKey);
         if (beforeIssueKey == null) {


### PR DESCRIPTION
rerankIssue method - variable issue was never used, method works with issues.keySet()
getIssueList method - substring is done via getIssue(...) - getProjectCode(...)
