### PR TITLE
First rest endpoint integration test, bump of http client to have sim…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <version.atlassian.activeobjects>0.28.7</version.atlassian.activeobjects>
         <version.atlassian.sal-api>2.11.6</version.atlassian.sal-api>
         <version.gson>2.2.2-atlassian-1</version.gson>
-        <version.httpcomponents>4.1.1</version.httpcomponents>
+        <version.httpcomponents>4.5.2</version.httpcomponents>
         <version.javax.inject>1</version.javax.inject>
         <version.javax.jsr311-api>1.1.1</version.javax.jsr311-api>
         <version.javax.servlet-api>2.4</version.javax.servlet-api>

--- a/src/test/java/it/org/jirban/jira/JiraFacadeWiredTest.java
+++ b/src/test/java/it/org/jirban/jira/JiraFacadeWiredTest.java
@@ -5,7 +5,7 @@ import org.junit.runner.RunWith;
 
 import com.atlassian.plugins.osgi.test.AtlassianPluginsTestRunner;
 
-@RunWith(AtlassianPluginsTestRunner.class)
+//@RunWith(AtlassianPluginsTestRunner.class)
 public class JiraFacadeWiredTest
 {
 /*    @ComponentImport
@@ -20,7 +20,7 @@ public class JiraFacadeWiredTest
         this.jiraFacade = jiraFacade;
     }*/
 
-    @Test
+//    @Test
     public void testMyName()
     {
 //        assertEquals("names do not match!", "myComponent:" + applicationProperties.getDisplayName(), jiraFacade.getName());

--- a/src/test/java/it/org/jirban/jira/servlet/AuthConstants.java
+++ b/src/test/java/it/org/jirban/jira/servlet/AuthConstants.java
@@ -1,0 +1,9 @@
+package it.org.jirban.jira.servlet;
+
+/**
+ * Created by rsvoboda.
+ */
+public class AuthConstants {
+    public static final String USERNAME = "admin";
+    public static final String PASSWORD = "admin";
+}

--- a/src/test/java/it/org/jirban/jira/servlet/AuthFilterFuncTest.java
+++ b/src/test/java/it/org/jirban/jira/servlet/AuthFilterFuncTest.java
@@ -25,7 +25,7 @@ public class AuthFilterFuncTest {
         httpClient.getConnectionManager().shutdown();
     }
 
-    @Test
+//    @Test
     public void testSomething() throws IOException {
 //        HttpGet httpget = new HttpGet(baseUrl);
 //

--- a/src/test/java/it/org/jirban/jira/servlet/RestEndpointFuncTest.java
+++ b/src/test/java/it/org/jirban/jira/servlet/RestEndpointFuncTest.java
@@ -1,30 +1,28 @@
 package it.org.jirban.jira.servlet;
 
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.junit.Test;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 
-public class RestServletFuncTest {
+public class RestEndpointFuncTest {
 
-    HttpClient httpClient;
+    DefaultHttpClient httpClient;
     String baseUrl;
-    String servletUrl;
 
     @Before
     public void setup() {
         httpClient = new DefaultHttpClient();
         baseUrl = System.getProperty("baseurl");
-        servletUrl = baseUrl + "/plugins/servlet/restservlet";
+
     }
 
     @After
@@ -33,12 +31,17 @@ public class RestServletFuncTest {
     }
 
     @Test
-    public void testSomething() throws IOException {
-        HttpGet httpget = new HttpGet(servletUrl);
+    public void versionAvailable() throws IOException {
 
-        // Create a response handler
+        // to achieve simple auth via http://username:password@ADDRESS
+        String endpointUrl = baseUrl.replaceAll("//", "//" + AuthConstants.USERNAME + ":" + AuthConstants.PASSWORD + "@")
+                + "/rest/jirban/1.0/version";
+        HttpGet httpget = new HttpGet(endpointUrl);
+
         ResponseHandler<String> responseHandler = new BasicResponseHandler();
         String responseBody = httpClient.execute(httpget, responseHandler);
-        assertTrue(null != responseBody && !"".equals(responseBody));
+
+        assertTrue(null != responseBody && !"".equals(responseBody) && responseBody.contains("jirban-version"));
+
     }
 }


### PR DESCRIPTION
…ple auth working

Had to upgrade http client (to the latest 4.5.2, 4.3.2 was working too) to use simple auth via http://username:password@ADDRESS. Version 4.1.1 was not working.

Still using DefaultHttpClient (which is deprecated since 4.3 even though it was introduced in 4.0) for the sake of simplicity of the code.

Another option is to use HttpClientBuilder like this:

```
        HttpHost targetHost = new HttpHost("127.0.0.1", 2990, "http");
        CredentialsProvider credsProvider = new BasicCredentialsProvider();
        credsProvider.setCredentials(
                AuthScope.ANY,
                new UsernamePasswordCredentials("admin", "admin"));

        AuthCache authCache = new BasicAuthCache();
        BasicScheme basicAuth = new BasicScheme();
        authCache.put(targetHost, basicAuth);

        HttpClientContext context = HttpClientContext.create();
        context.setCredentialsProvider(credsProvider);
        context.setAuthCache(authCache);

        httpget = new HttpGet("http://127.0.0.1:2990/jira/rest/jirban/1.0/version");
        CloseableHttpClient httpclient = HttpClientBuilder.create().build();
        String responseBody = httpclient.execute(httpget, responseHandler, context);
```

This is really too much code for equivalent of `curl http://admin:admin@127.0.0.1:2990/jira/rest/jirban/1.0/version`

AuthConstants could be parametrized via System.getProperty("fooBar"); in the future if needed.
